### PR TITLE
use `buffer` instead of `native-buffer-browserify`

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -4,7 +4,7 @@ path = require 'path'
 fs = require 'fs'
 binaryXHR = require 'binary-xhr'
 EventEmitter = (require 'events').EventEmitter
-Buffer = (require 'native-buffer-browserify').Buffer # >=2.0.9 for fix https://github.com/feross/native-buffer-browserify/issues/16
+Buffer = (require 'buffer/').Buffer # >=2.0.9 for fix https://github.com/feross/buffer/issues/16
 getFrames = require 'mcmeta'
 getPixels = require 'get-pixels'
 savePixels = require 'save-pixels'

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
 
   EventEmitter = (require('events')).EventEmitter;
 
-  Buffer = (require('native-buffer-browserify')).Buffer;
+  Buffer = (require('buffer/')).Buffer;
 
   getFrames = require('mcmeta');
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "zip": "^1.2.0",
     "binary-xhr": "^0.0.2",
-    "native-buffer-browserify": ">=2.0.9",
+    "buffer": ">=2.1.12",
     "mcmeta": "^0.1.0",
     "get-pixels": "^1.0.1",
     "save-pixels": "^0.3.0",


### PR DESCRIPTION
The module has been renamed and all the latest fixes are going into `buffer`. :)
